### PR TITLE
Add new product variable DeviceIsContainer

### DIFF
--- a/core/product.mk
+++ b/core/product.mk
@@ -289,6 +289,7 @@ _product_stash_var_list += \
 	BOARD_VENDORIMAGE_PARTITION_SIZE \
 	BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE \
 	BOARD_INSTALLER_CMDLINE \
+	BOARD_IS_CONTAINER \
 
 
 _product_stash_var_list += \

--- a/core/soong_config.mk
+++ b/core/soong_config.mk
@@ -52,6 +52,7 @@ $(SOONG_VARIABLES): FORCE
 	echo '    "DeviceAbi": ["$(TARGET_CPU_ABI)", "$(TARGET_CPU_ABI2)"],'; \
 	echo '    "DeviceUsesClang": $(if $(USE_CLANG_PLATFORM_BUILD),$(USE_CLANG_PLATFORM_BUILD),false),'; \
 	echo '    "DeviceVndkVersion": "$(BOARD_VNDK_VERSION)",'; \
+	echo '    "DeviceIsContainer": $(if $(filter true,$(BOARD_IS_CONTAINER)),true,false),'; \
 	echo ''; \
 	echo '    "DeviceSecondaryArch": "$(TARGET_2ND_ARCH)",'; \
 	echo '    "DeviceSecondaryArchVariant": "$(TARGET_2ND_ARCH_VARIANT)",'; \


### PR DESCRIPTION
To accommodate to container based, less priviledged environment, some functions have to be disabled to successfully launch Android runtime. DeviceIsContainer is supposed to be set to true when BOARD_IS_CONTAINER is defined in per device BoardConfig.mk, and will inject C proprocessor definition ANDROID_CONTAINER for all native device modules.